### PR TITLE
update docs to install required modules

### DIFF
--- a/python/2.7/readme.txt
+++ b/python/2.7/readme.txt
@@ -7,6 +7,8 @@ Set PYTHONPATH to the src sub-directory
 
 On Windows perform "CHCP 65001" to set the console in UTF-8 mode
 
+Install required modules:
+$ pip install ecdsa pycrypto simplejson
 
 2. Running
 ----------


### PR DESCRIPTION
this also gets rid of the ctrl-M's at the end of the file.  This should be handled by git automagically to add the required line endings on Windows.